### PR TITLE
Add checks and cleanup to Test Suite

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/redhat-developer/openshift-jenkins-operator
-  newTag: 0.7.0-9ccc1b96
+  newTag: 0.7.0-6ae687ce

--- a/controllers/jenkins_controller_test.go
+++ b/controllers/jenkins_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	"github.com/jenkinsci/kubernetes-operator/api/v1alpha2"
 	"github.com/jenkinsci/kubernetes-operator/pkg/configuration/base"
@@ -20,18 +21,30 @@ import (
 // +kubebuilder:docs-gen:collapse=Imports
 
 const (
-	// Name                  = "test-image"
-	JenkinsName        = "test-jenkins"
-	MinimalJenkinsName = "minimal-jenkins"
-	JenkinsNamespace   = "default"
+	JenkinsName          = "test-jenkins"
+	MinimalJenkinsName   = "minimal-jenkins"
+	JenkinsTestNamespace = "jenkins-operator-test"
+	timeout              = time.Second * 30
+	interval             = time.Millisecond * 250
+)
+
+var (
+	jenkinsControllerTestNamespace *corev1.Namespace
 )
 
 var _ = Describe("Jenkins controller", func() {
-	Logf("Starting")
+	Logf("Starting test for Jenkins Controller")
+
+	Context("When Checking the Namespace for testing the Jenkins Controller", func() {
+		ctx := context.Background()
+		It("Test Namespace Should Be Present", func() {
+			ByCreatingNamespaceIsPresent(ctx, JenkinsTestNamespace)
+		})
+	})
 
 	Context("When Creating a Minimal Jenkins Instance", func() {
 		ctx := context.Background()
-		jenkins := GetMinimalJenkinsTestInstance(MinimalJenkinsName, JenkinsNamespace)
+		jenkins := GetMinimalJenkinsTestInstance(MinimalJenkinsName, JenkinsTestNamespace)
 		It("Deployment Should Be Created", func() {
 			CreateEditClusterRole(ctx)
 			ByCreatingJenkinsSuccesfully(ctx, jenkins)
@@ -43,7 +56,7 @@ var _ = Describe("Jenkins controller", func() {
 
 	Context("When Creating a Jenkins CR", func() {
 		ctx := context.Background()
-		jenkins := GetJenkinsTestInstance(JenkinsName, JenkinsNamespace)
+		jenkins := GetJenkinsTestInstance(JenkinsName, JenkinsTestNamespace)
 		It("Deployment Should Be Created", func() {
 			ByCreatingJenkinsSuccesfully(ctx, jenkins)
 			ByCheckingThatJenkinsExists(ctx, jenkins)
@@ -55,7 +68,7 @@ var _ = Describe("Jenkins controller", func() {
 		ctx := context.Background()
 		image := "my-image"
 		jenkinsWithImage := "jenkins-with-image"
-		jenkins := GetJenkinsTestInstanceWithMasterImage(jenkinsWithImage, JenkinsNamespace, image)
+		jenkins := GetJenkinsTestInstanceWithMasterImage(jenkinsWithImage, JenkinsTestNamespace, image)
 		It("Deployment Should Be Created With That Image Name", func() {
 			ByCreatingJenkinsSuccesfully(ctx, jenkins)
 			ByCheckingThatJenkinsExists(ctx, jenkins)
@@ -66,14 +79,37 @@ var _ = Describe("Jenkins controller", func() {
 })
 
 func CreateEditClusterRole(ctx context.Context) {
-	editClusterRole := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      base.EditClusterRole,
-			Namespace: JenkinsNamespace,
-		},
-		Rules: resources.NewDefaultPolicyRules(),
+	editClusterRole := &rbacv1.ClusterRole{}
+	nn := types.NamespacedName{Name: base.EditClusterRole, Namespace: JenkinsTestNamespace}
+	err := k8sClient.Get(ctx, nn, editClusterRole)
+	if err != nil {
+		editClusterRole = &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nn.Name,
+				Namespace: nn.Namespace,
+			},
+			Rules: resources.NewDefaultPolicyRules(),
+		}
+		Expect(k8sClient.Create(ctx, editClusterRole)).Should(Succeed())
 	}
-	Expect(k8sClient.Create(ctx, editClusterRole)).Should(Succeed())
+}
+
+func ByCreatingNamespaceIsPresent(ctx context.Context, namespaceName string){
+	By("Check if namespace exists")
+	jenkinsControllerTestNamespace = &corev1.Namespace{}
+	key := types.NamespacedName{Name: namespaceName}
+	err := k8sClient.Get(ctx, key, jenkinsControllerTestNamespace)
+
+	if err != nil {
+		By("Create Namespace")
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespaceName,
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+	}
+
 }
 
 func ByCheckingThatDeploymentImageIs(ctx context.Context, jenkins *v1alpha2.Jenkins) {

--- a/controllers/jenkinsimage_controller_test.go
+++ b/controllers/jenkinsimage_controller_test.go
@@ -3,8 +3,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"time"
-
 	"github.com/jenkinsci/kubernetes-operator/api/v1alpha2"
 	"github.com/jenkinsci/kubernetes-operator/pkg/configuration/base/resources"
 	. "github.com/onsi/ginkgo"
@@ -18,9 +16,6 @@ import (
 const (
 	// Name                  = "test-image"
 	JenkinsImageName      = "test-jenkinsimage"
-	JenkinsImageNamespace = "default"
-	timeout               = time.Second * 30
-	interval              = time.Millisecond * 250
 	// duration = time.Second * 10
 )
 
@@ -31,7 +26,7 @@ var _ = Describe("JenkinsImage controller", func() {
 		It("The Pod should be recreated", func() {
 			Logf("Starting")
 			ctx := context.Background()
-			jenkinsImage := GetJenkinsImageTestInstance(JenkinsImageName, JenkinsImageNamespace)
+			jenkinsImage := GetJenkinsImageTestInstance(JenkinsImageName, JenkinsTestNamespace)
 			ByCreatingJenkinsImageSuccesfully(ctx, jenkinsImage)
 			ByCheckingThatJenkinsImageExists(ctx, jenkinsImage)
 			ByCheckingThatThePodExists(ctx, jenkinsImage)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -156,6 +157,9 @@ func registerJenkinsController(manager manager.Manager, c *rest.Config) {
 }
 
 var _ = AfterSuite(func() {
+	By("Remove all Namespaces")
+	Expect(k8sClient.Delete(context.Background(), jenkinsControllerTestNamespace)).Should(Succeed())
+
 	By("tearing down the test environment")
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Updated the Test Suite with the following
- Add check for presence of "edit" ClusterRole so that tests don't fail abruptly on Openshift
- Create a separate Namespace for testing
- Added AfterSuite which will delete the test namespace